### PR TITLE
Fix checkbox listeners after DataTable redraw

### DIFF
--- a/js/visualization.js
+++ b/js/visualization.js
@@ -87,6 +87,9 @@ OCA.ShareReview.Visualization = {
             },
         });
 
+        // Reattach the checkbox listeners whenever the table is redrawn
+        OCA.ShareReview.tableObject.on('draw', OCA.ShareReview.UI.initCheckboxListeners);
+
         let headerCheckbox = document.getElementById('selectAllShares');
         if (headerCheckbox) {
             headerCheckbox.addEventListener('change', OCA.ShareReview.UI.handleSelectAll);


### PR DESCRIPTION
## Summary
- call `initCheckboxListeners` whenever the DataTable redraws to ensure newly
  generated checkboxes get listeners

## Testing
- `composer validate --no-check-publish` *(fails: command not found)*