### PR TITLE
Add talk share filter and navigation option

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -15,7 +15,8 @@ return [
         ['name' => 'output#read', 'url' => '/data', 'verb' => 'GET'],
 		['name' => 'output#readNew', 'url' => '/data/new', 'verb' => 'GET'],
 		['name' => 'output#delete', 'url' => '/delete/{shareId}', 'verb' => 'DELETE'],
-		['name' => 'output#confirm', 'url' => '/confirm', 'verb' => 'POST'],
-		['name' => 'output#confirmReset', 'url' => '/confirmReset', 'verb' => 'POST'],
+                ['name' => 'output#confirm', 'url' => '/confirm', 'verb' => 'POST'],
+                ['name' => 'output#confirmReset', 'url' => '/confirmReset', 'verb' => 'POST'],
+                ['name' => 'output#showTalk', 'url' => '/showTalk', 'verb' => 'POST'],
     ]
 ];

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -8,15 +8,15 @@
 
 
 return [
-    'routes' => [
-        ['name' => 'page#index', 'url' => '/', 'verb' => 'GET'],
+	'routes' => [
+		['name' => 'page#index', 'url' => '/', 'verb' => 'GET'],
 
-        // Output
-        ['name' => 'output#read', 'url' => '/data', 'verb' => 'GET'],
+		// Output
+		['name' => 'output#read', 'url' => '/data', 'verb' => 'GET'],
 		['name' => 'output#readNew', 'url' => '/data/new', 'verb' => 'GET'],
 		['name' => 'output#delete', 'url' => '/delete/{shareId}', 'verb' => 'DELETE'],
-                ['name' => 'output#confirm', 'url' => '/confirm', 'verb' => 'POST'],
-                ['name' => 'output#confirmReset', 'url' => '/confirmReset', 'verb' => 'POST'],
-                ['name' => 'output#showTalk', 'url' => '/showTalk', 'verb' => 'POST'],
-    ]
+		['name' => 'output#confirm', 'url' => '/confirm', 'verb' => 'POST'],
+		['name' => 'output#confirmReset', 'url' => '/confirmReset', 'verb' => 'POST'],
+		['name' => 'output#showTalk', 'url' => '/showTalk', 'verb' => 'POST'],
+	]
 ];

--- a/css/style.css
+++ b/css/style.css
@@ -123,6 +123,11 @@
     background-color: initial !important;
 }
 
+.pinned {
+    line-height: 44px;
+    padding-left: 10px;
+}
+
 /* make the pagination smaller */
 div.dt-container .dt-paging .dt-paging-button {
     font-size: 12px;

--- a/js/app.js
+++ b/js/app.js
@@ -42,6 +42,7 @@ OCA.ShareReview.Navigation = {
     buildNavigation: function (data) {
         document.getElementById('shareReviewNavigation').innerHTML = '';
         let reviewTimestamp = OCA.ShareReview.Navigation.getInitialState('reviewTimestamp');
+        let showTalk = OCA.ShareReview.Navigation.getInitialState('showTalk');
         let localTime = '';
         if (reviewTimestamp !== '0') {
             let timestampInMilliseconds = reviewTimestamp * 1000;
@@ -90,6 +91,21 @@ OCA.ShareReview.Navigation = {
         for (let navigation of navigations) {
             document.getElementById('shareReviewNavigation').appendChild(OCA.ShareReview.Navigation.buildNavigationRow(navigation));
         }
+
+        let liTalk = document.createElement('li');
+        liTalk.classList.add('pinned', 'first-pinned');
+        let checkbox = document.createElement('input');
+        checkbox.type = 'checkbox';
+        checkbox.id = 'showTalkShares';
+        checkbox.checked = showTalk;
+        checkbox.classList.add('checkbox');
+        checkbox.addEventListener('change', OCA.ShareReview.Navigation.handleShowTalkChange);
+        let label = document.createElement('label');
+        label.setAttribute('for', 'showTalkShares');
+        label.innerText = t('sharereview', 'Show talk shares');
+        liTalk.appendChild(checkbox);
+        liTalk.appendChild(label);
+        document.getElementById('shareReviewNavigation').appendChild(liTalk);
     },
 
     buildNavigationRow: function (data) {
@@ -122,6 +138,11 @@ OCA.ShareReview.Navigation = {
 
     handleConfirmResetNavigation: function () {
         OCA.ShareReview.Backend.confirmReset();
+    },
+
+    handleShowTalkChange: function () {
+        let state = document.getElementById('showTalkShares').checked;
+        OCA.ShareReview.Backend.showTalk(state);
     },
 
     getInitialState: function (key) {
@@ -207,6 +228,19 @@ OCA.ShareReview.Backend = {
             .then(data => {
                 OCA.ShareReview.Notification.notification('success', t('sharereview', 'Timestamp deleted'));
                 document.getElementById('navTime').firstChild.innerText = '';
+            });
+    },
+
+    showTalk: function(state) {
+        let requestUrl = OC.generateUrl('apps/sharereview/showTalk');
+        fetch(requestUrl, {
+            method: 'POST',
+            headers: OCA.ShareReview.headers(),
+            body: JSON.stringify({state: state})
+        })
+            .then(response => response.json())
+            .then(data => {
+                OCA.ShareReview.Backend.getData();
             });
     },
 };

--- a/js/app.js
+++ b/js/app.js
@@ -42,7 +42,7 @@ OCA.ShareReview.Navigation = {
     buildNavigation: function (data) {
         document.getElementById('shareReviewNavigation').innerHTML = '';
         let reviewTimestamp = OCA.ShareReview.Navigation.getInitialState('reviewTimestamp');
-        let showTalk = OCA.ShareReview.Navigation.getInitialState('showTalk');
+        let showTalk = OCA.ShareReview.Navigation.getInitialState('showTalk') === "true";
         let localTime = '';
         if (reviewTimestamp !== '0') {
             let timestampInMilliseconds = reviewTimestamp * 1000;
@@ -141,7 +141,7 @@ OCA.ShareReview.Navigation = {
     },
 
     handleShowTalkChange: function () {
-        let state = document.getElementById('showTalkShares').checked;
+        let state = document.getElementById('showTalkShares').checked.toString();
         OCA.ShareReview.Backend.showTalk(state);
     },
 

--- a/l10n/en_GB.js
+++ b/l10n/en_GB.js
@@ -26,6 +26,7 @@ OC.L10N.register(
     "Pause reload after deletion" : "Pause reload after deletion",
     "No share found" : "No share found",
     "The app must be restricted to at least one specific user group in the app store. This prevents accidental exposure of the shared content to all users." : "The app must be restricted to at least one specific user group in the app store. This prevents accidental exposure of the shared content to all users.",
-    "Click here" : "Click here"
+    "Click here" : "Click here",
+    "Show talk shares" : "Show talk shares"
 },
 "nplurals=2; plural=(n != 1);");

--- a/l10n/en_GB.json
+++ b/l10n/en_GB.json
@@ -24,6 +24,7 @@
     "Pause reload after deletion" : "Pause reload after deletion",
     "No share found" : "No share found",
     "The app must be restricted to at least one specific user group in the app store. This prevents accidental exposure of the shared content to all users." : "The app must be restricted to at least one specific user group in the app store. This prevents accidental exposure of the shared content to all users.",
-    "Click here" : "Click here"
+    "Click here" : "Click here",
+    "Show talk shares" : "Show talk shares"
 },"pluralForm" :"nplurals=2; plural=(n != 1);"
 }

--- a/lib/Controller/OutputController.php
+++ b/lib/Controller/OutputController.php
@@ -103,13 +103,28 @@ class OutputController extends Controller {
 	 * @return DataResponse
 	 * @throws ShareNotFound
 	 */
-	public function confirmReset() {
-		if (!$this->ShareService->isSecured()) {
-			return new DataResponse('', HTTP::STATUS_FORBIDDEN);
-		}
-		$result = $this->ShareService->confirm(0);
-		return new DataResponse($result, HTTP::STATUS_OK);
-	}
+        public function confirmReset() {
+                if (!$this->ShareService->isSecured()) {
+                        return new DataResponse('', HTTP::STATUS_FORBIDDEN);
+                }
+                $result = $this->ShareService->confirm(0);
+                return new DataResponse($result, HTTP::STATUS_OK);
+        }
+
+       /**
+        * persist talk share visibility
+        *
+        * @NoAdminRequired
+        * @return DataResponse
+        */
+       public function showTalk() {
+               if (!$this->ShareService->isSecured()) {
+                       return new DataResponse('', HTTP::STATUS_FORBIDDEN);
+               }
+               $state = $this->request->getParam('state') === 'true';
+               $result = $this->ShareService->showTalk($state);
+               return new DataResponse($result, HTTP::STATUS_OK);
+       }
 
 	/**
 	 * app can only be used when it is restricted to at least one group for security reasons

--- a/lib/Controller/OutputController.php
+++ b/lib/Controller/OutputController.php
@@ -117,12 +117,12 @@ class OutputController extends Controller {
         * @NoAdminRequired
         * @return DataResponse
         */
-       public function showTalk() {
+       public function showTalk($state) {
                if (!$this->ShareService->isSecured()) {
                        return new DataResponse('', HTTP::STATUS_FORBIDDEN);
                }
-               $state = $this->request->getParam('state') === 'true';
-               $result = $this->ShareService->showTalk($state);
+			   $state = $state === 'true';
+			   $result = $this->ShareService->showTalk($state);
                return new DataResponse($result, HTTP::STATUS_OK);
        }
 

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -51,7 +51,7 @@ class PageController extends Controller {
         public function index() {
                 $user = $this->userSession->getUser();
                 $this->initialState->provideInitialState('reviewTimestamp', $this->config->getUserValue($user->getUID(), 'sharereview', 'reviewTimestamp', 0));
-                $this->initialState->provideInitialState('showTalk', $this->config->getUserValue($user->getUID(), 'sharereview', 'showTalk', 'true'));
+                $this->initialState->provideInitialState('showTalk', $this->config->getUserValue($user->getUID(), 'sharereview', 'showTalk', 'false'));
                 $params = array();
                 return new TemplateResponse($this->appName, 'main', $params);
         }

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -48,10 +48,11 @@ class PageController extends Controller {
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
 	 */
-	public function index() {
-		$user = $this->userSession->getUser();
-		$this->initialState->provideInitialState('reviewTimestamp', $this->config->getUserValue($user->getUID(), 'sharereview', 'reviewTimestamp', 0));
-		$params = array();
-		return new TemplateResponse($this->appName, 'main', $params);
-	}
+        public function index() {
+                $user = $this->userSession->getUser();
+                $this->initialState->provideInitialState('reviewTimestamp', $this->config->getUserValue($user->getUID(), 'sharereview', 'reviewTimestamp', 0));
+                $this->initialState->provideInitialState('showTalk', $this->config->getUserValue($user->getUID(), 'sharereview', 'showTalk', 'true'));
+                $params = array();
+                return new TemplateResponse($this->appName, 'main', $params);
+        }
 }

--- a/lib/Service/ShareService.php
+++ b/lib/Service/ShareService.php
@@ -81,14 +81,14 @@ class ShareService {
 	 * @throws NotFoundException
 	 * @throws NotPermittedException
 	 */
-        public function read($onlyNew) {
-                $user = $this->userSession->getUser();
-                $userTimestamp = $this->config->getUserValue($user->getUID(), 'sharereview', 'reviewTimestamp', 0);
-                $showTalk = $this->config->getUserValue($user->getUID(), 'sharereview', 'showTalk', 'true') !== 'false';
-                $formated = [];
+	public function read($onlyNew) {
+		$user = $this->userSession->getUser();
+		$userTimestamp = $this->config->getUserValue($user->getUID(), 'sharereview', 'reviewTimestamp', 0);
+		$showTalk = $this->config->getUserValue($user->getUID(), 'sharereview', 'showTalk', 'true') !== 'false';
+		$formated = [];
 
-                $shares = $this->getFileShares($showTalk);
-                $appShares = $this->getAppShares();
+		$shares = $this->getFileShares($showTalk);
+		$appShares = $this->getAppShares();
 
 		$shares = array_merge($shares, $appShares);
 
@@ -131,23 +131,23 @@ class ShareService {
 	 * @return mixed
 	 * @throws PreConditionNotMetException
 	 */
-        public function confirm($timestamp) {
-                $user = $this->userSession->getUser();
-                $this->config->setUserValue($user->getUID(), 'sharereview', 'reviewTimestamp', $timestamp);
-                return $timestamp;
-        }
+	public function confirm($timestamp) {
+		$user = $this->userSession->getUser();
+		$this->config->setUserValue($user->getUID(), 'sharereview', 'reviewTimestamp', $timestamp);
+		return $timestamp;
+	}
 
-       /**
-        * persist showTalk selection
-        * @param bool $state
-        * @return bool
-        */
-       public function showTalk(bool $state) {
-               $user = $this->userSession->getUser();
-               $value = $state ? 'true' : 'false';
-               $this->config->setUserValue($user->getUID(), 'sharereview', 'showTalk', $value);
-               return $state;
-       }
+	/**
+	 * persist showTalk selection
+	 * @param bool $state
+	 * @return bool
+	 */
+	public function showTalk(bool $state) {
+		$user = $this->userSession->getUser();
+		$value = $state ? 'true' : 'false';
+		$this->config->setUserValue($user->getUID(), 'sharereview', 'showTalk', $value);
+		return $state;
+	}
 
 	/**
 	 * app can only be used when it is restricted to at least one group for security reasons
@@ -208,27 +208,27 @@ class ShareService {
 	 * @throws NotFoundException
 	 * @throws NotPermittedException
 	 */
-       private function getFileShares(bool $showTalk = true) {
-               $shares = $this->shareManager->getAllShares();
-               $formated = [];
+	private function getFileShares(bool $showTalk = true) {
+		$shares = $this->shareManager->getAllShares();
+		$formated = [];
 
-               foreach ($shares as $share) {
-                       if (!$showTalk && $share->getShareType() === IShare::TYPE_ROOM) {
-                               continue;
-                       }
-                       $path = '';
+		foreach ($shares as $share) {
+			if (!$showTalk && $share->getShareType() === IShare::TYPE_ROOM) {
+				continue;
+			}
+			$path = '';
 
 			if (!$this->userHelper->isValidOwner($share->getShareOwner())) {
-/*				$userFolder = $this->rootFolder->getUserFolder($share->getShareOwner());
-				$nodes = $userFolder->getById($share->getNodeId());
-				$node = array_shift($nodes);
+				/*				$userFolder = $this->rootFolder->getUserFolder($share->getShareOwner());
+								$nodes = $userFolder->getById($share->getNodeId());
+								$node = array_shift($nodes);
 
-				if ($node !== null && $userFolder !== null) {
-					$path = $userFolder->getRelativePath($node->getPath());
-				} else {
-					$path = 'invalid share (*) ' . $share->getTarget();
-				}
-			} else {*/
+								if ($node !== null && $userFolder !== null) {
+									$path = $userFolder->getRelativePath($node->getPath());
+								} else {
+									$path = 'invalid share (*) ' . $share->getTarget();
+								}
+							} else {*/
 				$path = 'invalid share (*) ';
 			}
 			$path = $path . $share->getTarget();


### PR DESCRIPTION
## Summary
- add backend route and service method to store talk share visibility
- filter talk room shares in `ShareService`
- provide `showTalk` initial state to the frontend
- add checkbox navigation item for "Show talk shares" and persist selection
- update English translations

## Testing
- `git log -1 --stat`