### PR TITLE
Add PDF export and scheduled audit reports

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -16,7 +16,11 @@ return [
 		['name' => 'output#readNew', 'url' => '/data/new', 'verb' => 'GET'],
 		['name' => 'output#delete', 'url' => '/delete/{shareId}', 'verb' => 'DELETE'],
 		['name' => 'output#confirm', 'url' => '/confirm', 'verb' => 'POST'],
-		['name' => 'output#confirmReset', 'url' => '/confirmReset', 'verb' => 'POST'],
-		['name' => 'output#showTalk', 'url' => '/showTalk', 'verb' => 'POST'],
-	]
+                ['name' => 'output#confirmReset', 'url' => '/confirmReset', 'verb' => 'POST'],
+                ['name' => 'output#showTalk', 'url' => '/showTalk', 'verb' => 'POST'],
+
+                // Report
+                ['name' => 'report#export', 'url' => '/report/export', 'verb' => 'POST'],
+                ['name' => 'report#saveSettings', 'url' => '/report/settings', 'verb' => 'POST'],
+        ]
 ];

--- a/js/app.js
+++ b/js/app.js
@@ -123,6 +123,20 @@ OCA.ShareReview.Navigation = {
                 pinned: false
             },
             {
+                id: 'navExport',
+                name: t('sharereview', 'Export report'),
+                event: OCA.ShareReview.Navigation.handleExportNavigation,
+                style: 'icon-download',
+                pinned: false
+            },
+            {
+                id: 'navSettings',
+                name: t('sharereview', 'Settings'),
+                event: OCA.ShareReview.Navigation.handleSettingsNavigation,
+                style: 'icon-settings',
+                pinned: false
+            },
+            {
                 id: 'navTime',
                 name: localTime,
                 event: false,
@@ -167,12 +181,14 @@ OCA.ShareReview.Navigation = {
         document.getElementById('navAllShares').classList.add('active');
         document.getElementById('navNewShares').classList.remove('active');
         OCA.ShareReview.Backend.getData();
+        OCA.ShareReview.Visualization.hideElement('settingsContainer');
     },
 
     handleNewSharesNavigation: function () {
         document.getElementById('navNewShares').classList.add('active');
         document.getElementById('navAllShares').classList.remove('active');
         OCA.ShareReview.Backend.getData(true);
+        OCA.ShareReview.Visualization.hideElement('settingsContainer');
     },
 
     handleConfirmNavigation: function () {
@@ -181,6 +197,24 @@ OCA.ShareReview.Navigation = {
 
     handleConfirmResetNavigation: function () {
         OCA.ShareReview.Backend.confirmReset();
+    },
+
+    handleExportNavigation: function () {
+        OC.dialogs.filepicker(t('sharereview', 'Select folder'), function (path) {
+            if (path) {
+                OCA.ShareReview.Backend.export(path);
+            }
+        }, false, 'httpd', true, 'dir');
+    },
+
+    handleSettingsNavigation: function () {
+        OCA.ShareReview.Visualization.hideElement('tableContainer');
+        OCA.ShareReview.Visualization.hideElement('noDataContainer');
+        OCA.ShareReview.Visualization.hideElement('notSecuredContainer');
+        OCA.ShareReview.Visualization.hideElement('loadingContainer');
+        OCA.ShareReview.Visualization.showElement('settingsContainer');
+        document.getElementById('defaultFolder').value = OCA.ShareReview.Navigation.getInitialState('reportFolder') || '';
+        document.getElementById('scheduleSelect').value = OCA.ShareReview.Navigation.getInitialState('schedule') || 'none';
     },
 
     handleShowTalkChange: function () {
@@ -208,6 +242,7 @@ OCA.ShareReview.Backend = {
         OCA.ShareReview.Visualization.hideElement('noDataContainer');
         OCA.ShareReview.Visualization.hideElement('tableContainer');
         OCA.ShareReview.Visualization.hideElement('notSecuredContainer');
+        OCA.ShareReview.Visualization.hideElement('settingsContainer');
         fetch(requestUrl, {
             method: 'GET',
             headers: OCA.ShareReview.headers()
@@ -315,10 +350,57 @@ OCA.ShareReview.Backend = {
                 OCA.ShareReview.Backend.getData();
             });
     },
+
+    export: function(folder) {
+        let requestUrl = OC.generateUrl('apps/sharereview/report/export');
+        fetch(requestUrl, {
+            method: 'POST',
+            headers: OCA.ShareReview.headers(),
+            body: JSON.stringify({path: folder})
+        })
+            .then(response => response.json())
+            .then(() => {
+                OCA.ShareReview.Notification.notification('success', t('sharereview', 'Report created'));
+            })
+            .catch(() => {
+                OCA.ShareReview.Notification.notification('error', t('sharereview', 'Request could not be processed'));
+            });
+    },
+
+    saveSettings: function(folder, schedule) {
+        let requestUrl = OC.generateUrl('apps/sharereview/report/settings');
+        fetch(requestUrl, {
+            method: 'POST',
+            headers: OCA.ShareReview.headers(),
+            body: JSON.stringify({folder: folder, schedule: schedule})
+        })
+            .then(response => response.json())
+            .then(() => {
+                OCA.ShareReview.Notification.notification('success', t('sharereview', 'Settings saved'));
+            });
+    },
 };
 
 document.addEventListener('DOMContentLoaded', function () {
     OCA.ShareReview.Navigation.buildNavigation();
     OCA.ShareReview.Navigation.handleNewSharesNavigation();
     OCA.ShareReview.UI.initBulkActions();
+    let choose = document.getElementById('chooseDefaultFolder');
+    if (choose) {
+        choose.addEventListener('click', function () {
+            OC.dialogs.filepicker(t('sharereview', 'Select folder'), function (path) {
+                if (path) {
+                    document.getElementById('defaultFolder').value = path;
+                }
+            }, false, 'httpd', true, 'dir');
+        });
+    }
+    let save = document.getElementById('saveSettings');
+    if (save) {
+        save.addEventListener('click', function () {
+            let folder = document.getElementById('defaultFolder').value;
+            let schedule = document.getElementById('scheduleSelect').value;
+            OCA.ShareReview.Backend.saveSettings(folder, schedule);
+        });
+    }
 });

--- a/lib/BackgroundJob/GenerateReportJob.php
+++ b/lib/BackgroundJob/GenerateReportJob.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Share Review
+ *
+ * SPDX-FileCopyrightText: 2024 Marcel Scherello
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\ShareReview\BackgroundJob;
+
+use OCP\BackgroundJob\TimedJob;
+use OCP\IConfig;
+use OCA\ShareReview\Service\ReportService;
+
+class GenerateReportJob extends TimedJob {
+    private IConfig $config;
+    private ReportService $reportService;
+
+    public function __construct(IConfig $config, ReportService $reportService) {
+        $this->config = $config;
+        $this->reportService = $reportService;
+        $this->setInterval($this->getInterval());
+    }
+
+    protected function run($argument): void {
+        $interval = $this->getInterval();
+        if ($interval === 0) {
+            return;
+        }
+        $this->setInterval($interval);
+        $this->reportService->generateDefault();
+    }
+
+    private function getInterval(): int {
+        $schedule = $this->config->getAppValue('sharereview', 'schedule', 'none');
+        return match ($schedule) {
+            'daily' => 60 * 60 * 24,
+            'weekly' => 60 * 60 * 24 * 7,
+            'monthly' => 60 * 60 * 24 * 30,
+            default => 0,
+        };
+    }
+}

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -52,6 +52,8 @@ class PageController extends Controller {
                 $user = $this->userSession->getUser();
                 $this->initialState->provideInitialState('reviewTimestamp', $this->config->getUserValue($user->getUID(), 'sharereview', 'reviewTimestamp', 0));
                 $this->initialState->provideInitialState('showTalk', $this->config->getUserValue($user->getUID(), 'sharereview', 'showTalk', 'false'));
+                $this->initialState->provideInitialState('reportFolder', $this->config->getAppValue('sharereview', 'reportFolder', ''));
+                $this->initialState->provideInitialState('schedule', $this->config->getAppValue('sharereview', 'schedule', 'none'));
                 $params = array();
                 return new TemplateResponse($this->appName, 'main', $params);
         }

--- a/lib/Controller/ReportController.php
+++ b/lib/Controller/ReportController.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Share Review
+ *
+ * SPDX-FileCopyrightText: 2024 Marcel Scherello
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\ShareReview\Controller;
+
+use OCA\ShareReview\BackgroundJob\GenerateReportJob;
+use OCA\ShareReview\Service\ReportService;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\BackgroundJob\IJobList;
+use OCP\IConfig;
+use OCP\IRequest;
+use OCP\IUserSession;
+
+class ReportController extends Controller {
+    private ReportService $reportService;
+    private IConfig $config;
+    private IJobList $jobList;
+    private IUserSession $userSession;
+
+    public function __construct(string $appName,
+                                IRequest $request,
+                                ReportService $reportService,
+                                IConfig $config,
+                                IJobList $jobList,
+                                IUserSession $userSession) {
+        parent::__construct($appName, $request);
+        $this->reportService = $reportService;
+        $this->config = $config;
+        $this->jobList = $jobList;
+        $this->userSession = $userSession;
+    }
+
+    /**
+     * @NoAdminRequired
+     */
+    public function export(string $path): DataResponse {
+        $name = $this->reportService->generate($path);
+        return new DataResponse(['file' => $name], Http::STATUS_OK);
+    }
+
+    /**
+     * @NoAdminRequired
+     */
+    public function saveSettings(string $folder, string $schedule): DataResponse {
+        $user = $this->userSession->getUser();
+        $this->config->setAppValue('sharereview', 'reportOwner', $user->getUID());
+        $this->config->setAppValue('sharereview', 'reportFolder', $folder);
+        $this->config->setAppValue('sharereview', 'schedule', $schedule);
+
+        $this->jobList->remove(GenerateReportJob::class);
+        if ($schedule !== 'none') {
+            $this->jobList->add(GenerateReportJob::class);
+        }
+
+        return new DataResponse(['status' => 'ok'], Http::STATUS_OK);
+    }
+}

--- a/lib/Service/ReportService.php
+++ b/lib/Service/ReportService.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Share Review
+ *
+ * SPDX-FileCopyrightText: 2024 Marcel Scherello
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\ShareReview\Service;
+
+use OCP\Files\IRootFolder;
+use OCP\IUserSession;
+use OCP\IConfig;
+
+class ReportService {
+    private ShareService $shareService;
+    private IRootFolder $rootFolder;
+    private IUserSession $userSession;
+    private IConfig $config;
+
+    public function __construct(ShareService $shareService,
+                                IRootFolder $rootFolder,
+                                IUserSession $userSession,
+                                IConfig $config) {
+        $this->shareService = $shareService;
+        $this->rootFolder = $rootFolder;
+        $this->userSession = $userSession;
+        $this->config = $config;
+    }
+
+    /**
+     * Generate PDF report and store in the given folder for the given user
+     */
+    public function generate(string $folder, ?string $uid = null): string {
+        if ($uid === null) {
+            $uid = $this->userSession->getUser()->getUID();
+        }
+        $data = $this->shareService->read(false);
+
+        $pdf = new \TCPDF();
+        $pdf->AddPage();
+        $pdf->SetFont('helvetica', '', 16);
+        $pdf->Cell(0, 10, 'Share Review Report', 0, 1, 'C');
+        $pdf->SetFont('helvetica', '', 10);
+        $pdf->Cell(0, 10, 'Audit date: ' . (new \DateTime())->format('Y-m-d H:i'), 0, 1);
+        $html = '<table border="1" cellpadding="4"><thead><tr>' .
+            '<th>App</th><th>Object</th><th>Initiator</th><th>Recipient</th><th>Time</th></tr></thead><tbody>';
+        foreach ($data as $row) {
+            $html .= '<tr>' .
+                '<td>' . htmlspecialchars((string)$row['app']) . '</td>' .
+                '<td>' . htmlspecialchars((string)$row['object']) . '</td>' .
+                '<td>' . htmlspecialchars((string)$row['initiator']) . '</td>' .
+                '<td>' . htmlspecialchars((string)$row['recipient']) . '</td>' .
+                '<td>' . htmlspecialchars((string)$row['time']) . '</td>' .
+                '</tr>';
+        }
+        $html .= '</tbody></table>';
+        $pdf->writeHTML($html);
+        $content = $pdf->Output('', 'S');
+
+        $userFolder = $this->rootFolder->getUserFolder($uid);
+        $target = $userFolder->get($folder);
+        $fileName = 'share-report-' . date('YmdHis') . '.pdf';
+        $file = $target->newFile($fileName);
+        $file->putContent($content);
+
+        return $fileName;
+    }
+
+    /**
+     * Generate report using stored default folder
+     */
+    public function generateDefault(): void {
+        $owner = $this->config->getAppValue('sharereview', 'reportOwner', '');
+        $folder = $this->config->getAppValue('sharereview', 'reportFolder', '');
+        if ($owner === '' || $folder === '') {
+            return;
+        }
+        $this->generate($folder, $owner);
+    }
+}

--- a/templates/part.content.php
+++ b/templates/part.content.php
@@ -37,6 +37,27 @@
         <a href="/settings/apps/enabled/sharereview"><?php p($l->t('Click here')); ?></a>
     </div>
 
+    <div id="settingsContainer" hidden>
+        <h3><?php p($l->t('Report settings')); ?></h3>
+        <p>
+            <label for="defaultFolder"><?php p($l->t('Default folder')); ?></label>
+            <input type="text" id="defaultFolder" readonly>
+            <button id="chooseDefaultFolder" class="button"><?php p($l->t('Select')); ?></button>
+        </p>
+        <p>
+            <label for="scheduleSelect"><?php p($l->t('Schedule')); ?></label>
+            <select id="scheduleSelect">
+                <option value="none"><?php p($l->t('None')); ?></option>
+                <option value="daily"><?php p($l->t('Daily')); ?></option>
+                <option value="weekly"><?php p($l->t('Weekly')); ?></option>
+                <option value="monthly"><?php p($l->t('Monthly')); ?></option>
+            </select>
+        </p>
+        <p>
+            <button id="saveSettings" class="button"><?php p($l->t('Save')); ?></button>
+        </p>
+    </div>
+
 </div>
 <div id="shareReview-loading" style="width:100%; padding: 100px 5%;" hidden>
     <div style="text-align:center; padding-top:100px" class="get-metadata icon-loading"></div>


### PR DESCRIPTION
## Summary
- allow exporting current share report to PDF on the server
- add settings to choose default folder and schedule generation
- register background job using Nextcloud cron to create reports regularly

## Testing
- `php -l lib/Service/ReportService.php`
- `php -l lib/BackgroundJob/GenerateReportJob.php`
- `php -l lib/Controller/ReportController.php`
- `php -l lib/Controller/PageController.php`


------
https://chatgpt.com/codex/tasks/task_e_68bbd5d4c6b08333aaed22333ac3a588